### PR TITLE
Fix wrong highlighted date

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -175,7 +175,7 @@
           "type": "canceled"
         },
         {
-          "date": "2019-10-8",
+          "date": "2019-10-08",
           "type": "lecture",
           "topics": "embeddings",
           "notes": "lecture-06-embeddings.html",


### PR DESCRIPTION
The code use the date as a string to compare and figure out what day to highlight. Having a date without 0 padding cause a bug in the comparision.